### PR TITLE
Adicionando suporte a rota Empresa; Adicionando IE para o Prestador.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ composer.phar
 /vendor/
 /report/
 teste.php
+.phpunit.result.cache
 # Commit your application's lock file https://getcomposer.org/doc/01-basic-usage.md#commit-your-composer-lock-file-to-version-control
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file
 # composer.lock

--- a/examples/nfse.prestador.create.php
+++ b/examples/nfse.prestador.create.php
@@ -1,6 +1,6 @@
 <?php
 
-require '../vendor/autoload.php';
+require '/home/thiago_ribeiro/Projetos/github.com/plugnotas-php/vendor/autoload.php';
 
 use TecnoSpeed\Plugnotas\Nfse\Prestador;
 use TecnoSpeed\Plugnotas\Configuration;
@@ -8,18 +8,24 @@ use TecnoSpeed\Plugnotas\Communication\CallApi;
 
 try {
     $prestador = Prestador::fromArray([
-        'cpfCnpj' => '00.000.000/0001-91',
+        'cpfCnpj' => '80.681.272/0001-33',
         'inscricaoMunicipal' => '123456',
         'razaoSocial' => 'Razao Social do Prestador',
+        'simplesNacional' => true,
         'endereco' => [
             'logradouro' => 'Rua de Teste',
             'numero' => '1234',
             'codigoCidade' => '4115200',
-            'cep' => '87.050-800'
+            'cep' => '87.050-800',
+            'estado' => 'PR',
+            'bairro' => 'CENTRO'
+        ],
+        'nfse' => [
+            'ativo' => true
         ]
     ]);
 
-    $configuration = new Configuration();
+    $configuration = new Configuration(Configuration::TYPE_ENVIRONMENT_SANDBOX);
     $response = $prestador->send($configuration);
 
     var_dump($response);

--- a/src/Common/Nfse.php
+++ b/src/Common/Nfse.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace TecnoSpeed\Plugnotas\Common;
+
+use TecnoSpeed\Plugnotas\Abstracts\BuilderAbstract;
+use TecnoSpeed\Plugnotas\Error\ValidationError;
+use Respect\Validation\Validator as v;
+
+class Nfse extends BuilderAbstract
+{
+    private $ativo;
+    private $tipoContrato;
+
+    public function setAtivo($ativo)
+    {
+        if (
+            is_null($ativo) ||
+            !v::boolVal()->validate($ativo)
+        ) {
+            throw new ValidationError(
+                'Ativo é requerido para o cadastro de NFS-e.'
+            );
+        }
+
+        $this->ativo = $ativo;       
+    }
+
+    public function getAtivo()
+    {
+        return $this->ativo;
+    }    
+
+    public function setTipoContrato($tipoContrato)
+    {
+        if (
+            !is_null($tipoContrato) &&
+            !($tipoContrato === 0 ||
+            $tipoContrato === 1)
+        ){
+            throw new ValidationError(
+                'Valor inválido para o TipoContrato. Valores aceitos: null, 0, 1'
+            );            
+        }
+
+        $this->tipoContrato = $tipoContrato;        
+    }
+
+    public function getTipoContrato()
+    {
+        return $this->tipoContrato;
+    }  
+}

--- a/src/Nfse/Prestador.php
+++ b/src/Nfse/Prestador.php
@@ -13,6 +13,7 @@ use TecnoSpeed\Plugnotas\Error\InvalidTypeError;
 use TecnoSpeed\Plugnotas\Error\RequiredError;
 use TecnoSpeed\Plugnotas\Error\ValidationError;
 use TecnoSpeed\Plugnotas\Traits\Communication;
+use TecnoSpeed\Plugnotas\Common\Nfse;
 
 class Prestador extends BuilderAbstract
 {
@@ -25,12 +26,14 @@ class Prestador extends BuilderAbstract
     private $incentivadorCultural;
     private $incentivoFiscal;
     private $inscricaoMunicipal;
+    private $inscricaoEstadual;
     private $nomeFantasia;
     private $razaoSocial;
     private $regimeTributario;
     private $regimeTributarioEspecial;
     private $simplesNacional;
     private $telefone;
+    private $nfse;
 
     public function setCertificado($certificado)
     {
@@ -107,6 +110,16 @@ class Prestador extends BuilderAbstract
         return $this->endereco;
     }
 
+    public function setNfse(Nfse $nfse)
+    {
+        $this->nfse = $nfse;
+    }
+
+    public function getNfse()
+    {
+        return $this->nfse;
+    }
+
     public function setIncentivadorCultural($incentivadorCultural)
     {
         $this->incentivadorCultural = $incentivadorCultural;
@@ -129,17 +142,22 @@ class Prestador extends BuilderAbstract
 
     public function setInscricaoMunicipal($inscricaoMunicipal)
     {
-        if (is_null($inscricaoMunicipal)) {
-            throw new ValidationError(
-                'Inscrição municipal é requerida para NFSe.'
-            );
-        }
         $this->inscricaoMunicipal = $inscricaoMunicipal;
     }
 
     public function getInscricaoMunicipal()
     {
         return $this->inscricaoMunicipal;
+    }
+
+    public function setInscricaoEstadual($inscricaoEstadual)
+    {
+        $this->inscricaoEstadual = $inscricaoEstadual;
+    }
+
+    public function getInscricaoEstadual()
+    {
+        return $this->inscricaoEstadual;
     }
 
     public function setNomeFantasia($nomeFantasia)
@@ -229,6 +247,10 @@ class Prestador extends BuilderAbstract
             $data['endereco'] = Endereco::fromArray($data['endereco']);
         }
 
+        if (array_key_exists('nfse', $data)) {
+            $data['nfse'] = Nfse::fromArray($data['nfse']);
+        }    
+
         return Hydrate::toObject(self::class, $data);
     }
 
@@ -238,7 +260,6 @@ class Prestador extends BuilderAbstract
         if(
             !v::allOf(
                 v::keyNested('cpfCnpj'),
-                v::keyNested('inscricaoMunicipal'),
                 v::keyNested('razaoSocial'),
                 v::keyNested('simplesNacional'),
                 v::keyNested('endereco.logradouro'),
@@ -260,6 +281,6 @@ class Prestador extends BuilderAbstract
         $this->validate();
 
         $communication = $this->getCallApiInstance($configuration);
-        return $communication->send('POST', '/nfse/prestador', $this->toArray(true));
+        return $communication->send('POST', '/empresa', $this->toArray(true));
     }
 }

--- a/tests/Builders/NfseBuilderTest.php
+++ b/tests/Builders/NfseBuilderTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use TecnoSpeed\Plugnotas\Builders\NfseBuilder;
 use TecnoSpeed\Plugnotas\Common\Endereco;
 use TecnoSpeed\Plugnotas\Common\Telefone;
+use TecnoSpeed\Plugnotas\Common\Nfse;
 use TecnoSpeed\Plugnotas\Error\InvalidTypeError;
 use TecnoSpeed\Plugnotas\Error\ValidationError;
 use TecnoSpeed\Plugnotas\Nfse\CidadePrestacao;


### PR DESCRIPTION
Alterado para consumir a rota de cadastro /Empresa;
Adicionado nova propriedade "nfse" ao Prestador; Exemplo em examples/nfse.prestador.create.php
Removido obrigatoriedade de IM no cadastrado de Prestador;