### PR TITLE
Resolver problema de versão requerida pelo composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "test": "vendor/bin/phpunit --version"
   },
   "require": {
-    "php": "^7.0",
+    "php": "^7.0|^8.0",
     "respect/validation": "^1.1",
     "ferfabricio/hydrator": "^2.0",
     "guzzlehttp/guzzle": "^7.3",


### PR DESCRIPTION
### O que foi feito?

Adicionei a possibilidade de instalar a lib em outros versões mais recentes do PHP.

### O que resolve?

Resolve o problema de versão requerida ser apenas a versão 7.* ao instalar em projetos mais novos que estão rodando na versão 8 do php. 

### Teste:
Atualmente já uso ele em um projeto com php8.1, só que tenho que ignorar o que é requerido pelo composer.